### PR TITLE
Add parser for graphql and typescript files

### DIFF
--- a/src/inspectortodo/parser/GraphqlTodoParser.py
+++ b/src/inspectortodo/parser/GraphqlTodoParser.py
@@ -1,0 +1,9 @@
+# Copyright 2018 TNG Technology Consulting GmbH, Unterföhring, Germany
+# Licensed under the Apache License, Version 2.0 - see LICENSE.md in project root directory
+
+from .BaseTodoParser import BaseTodoParser
+
+
+class GraphqlTodoParser(BaseTodoParser):
+    def __init__(self, keywords):
+        super().__init__('#', '"""', '"""', keywords)

--- a/src/inspectortodo/parser/__init__.py
+++ b/src/inspectortodo/parser/__init__.py
@@ -10,3 +10,4 @@ from .PythonTodoParser import PythonTodoParser
 from .XmlTodoParser import XmlTodoParser
 from .YamlTodoParser import YamlTodoParser
 from .FtlTodoParser import FtlTodoParser
+from .GraphqlTodoParser import GraphqlTodoParser

--- a/src/inspectortodo/todo_finder.py
+++ b/src/inspectortodo/todo_finder.py
@@ -7,7 +7,7 @@ import os
 from git import GitError, InvalidGitRepositoryError, Repo
 
 from .parser import (BashTodoParser, JavaTodoParser, PythonTodoParser, XmlTodoParser, PhpTodoParser, CsharpTodoParser,
-                     JavaScriptTodoParser, YamlTodoParser, FtlTodoParser, JAVA_ANNOTATIONS)
+                     JavaScriptTodoParser, YamlTodoParser, FtlTodoParser, GraphqlTodoParser, JAVA_ANNOTATIONS)
 
 TODO_KEYWORDS = ['TODO']
 
@@ -30,6 +30,7 @@ class TodoFinder(object):
         self.javascript_parser = JavaScriptTodoParser(self.todo_keywords)
         self.yaml_parser = YamlTodoParser(self.todo_keywords)
         self.ftl_parser = FtlTodoParser(self.todo_keywords)
+        self.graphql_parser = GraphqlTodoParser(self.todo_keywords)
 
         self.num_files = 0
 
@@ -123,6 +124,14 @@ class TodoFinder(object):
         elif file_extension == '.ftl':
             log.debug("Parsing Ftl file %s", relative_path)
             return self.ftl_parser.get_todos(absolute_path, relative_path)
+        elif file_extension == '.ts':
+            log.debug("Parsing TypeScript file %s", relative_path)
+            js_todos = self.javascript_parser.get_todos(absolute_path, relative_path)
+            graphql_todos = self.graphql_parser.get_todos(absolute_path, relative_path)
+            return js_todos + graphql_todos
+        elif file_extension == '.graphql':
+            log.debug("Parsing Graphql file %s", relative_path)
+            return self.graphql_parser.get_todos(absolute_path, relative_path)
         else:
             log.debug("Skipping unknown file type of file %s", relative_path)
             return []

--- a/tests/inspectortodo/project_for_testing/graphql/schema.graphql
+++ b/tests/inspectortodo/project_for_testing/graphql/schema.graphql
@@ -1,0 +1,4 @@
+type Test {
+    """ TODO IT-3333 find something more to test """
+    code: String
+}

--- a/tests/inspectortodo/project_for_testing/typescript/test.ts
+++ b/tests/inspectortodo/project_for_testing/typescript/test.ts
@@ -1,0 +1,13 @@
+const testVariable = "amazing string";
+
+function wait() {
+    // TODO IT-6666 return more amazing strings
+    return testVariable;
+}
+
+if (testVariable) {
+    /*
+    TODO IT-3456 my todo can also go over several lines
+     */
+    wait();
+}

--- a/tests/inspectortodo/test_todo_finder.py
+++ b/tests/inspectortodo/test_todo_finder.py
@@ -7,9 +7,9 @@ from git import Repo
 
 from inspectortodo.todo_finder import TodoFinder
 
-FIND_GIT_NUM_FILES = 15
-FIND_BARE_NUM_FILES = 9
-NUM_TODOS = 14
+FIND_GIT_NUM_FILES = 17
+FIND_BARE_NUM_FILES = 11
+NUM_TODOS = 17
 
 
 def test_find_bare():


### PR DESCRIPTION
* typescript files can use the javascript parser
* as ts files can also include graphql snippets the graphql parser is also used on ts files

I hereby agree to the terms of the InspectorTodo Contributor License Agreement. Denise Meinhardt, denise.meinhardt@tngtech.com