### PR TITLE
Expose inspect functionality as Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Install and update using pip:
 
     pip install inspectortodo
 
-Then you can run InspectorTodo:
+Then you can run InspectorTodo from the command line,
 
     inspectortodo --help
+
+or invoke its API from your Python code (see example below).
 
 If you installed it in a virtualenv (which is recommended), then you always have to activate the virtualenv first.
 
@@ -20,6 +22,16 @@ The source code of InspectorTodo contains a small example project which can be p
 are at project root of InspectorTodo)
 
     inspectortodo ./tests/inspectortodo/project_for_testing "IT-\d+" --version-pattern "Release-\d+" --version 2 --versions 1,2,3
+
+Equivalent example in Python:
+
+```python
+import inspectortodo
+
+# The inspect() function takes the same arguments as the CLI
+inspectortodo.inspect(root_dir="./tests/inspectortodo/project_for_testing", issue_pattern="IT-\d+", version_pattern="Release-\d+", version="2", versions="1,2,3")
+```
+
 
 ### Traversing the folder tree
 

--- a/src/inspectortodo/__init__.py
+++ b/src/inspectortodo/__init__.py
@@ -1,0 +1,1 @@
+from .main import inspect

--- a/src/inspectortodo/main.py
+++ b/src/inspectortodo/main.py
@@ -31,6 +31,12 @@ log = logging.getLogger()
               help="Set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)")
 def main(root_dir, issue_pattern, version_pattern, version, versions, configfile, jira_user, jira_password, jira_token,
          issue_filter_field, issue_filter_values, xml, log_level):
+    inspect(root_dir, issue_pattern, version_pattern, version, versions, configfile, jira_user, jira_password, jira_token,
+         issue_filter_field, issue_filter_values, xml, log_level)
+
+
+def inspect(root_dir, issue_pattern, version_pattern=None, version=None, versions=None, configfile=None, jira_user=None, jira_password=None, jira_token=None,
+         issue_filter_field=None, issue_filter_values=None, xml=None, log_level="INFO"):
     r"""
     ROOT_DIR is the directory to inspect recursively.
 

--- a/tests/inspectortodo/test_main.py
+++ b/tests/inspectortodo/test_main.py
@@ -1,7 +1,8 @@
 import io
+import os
 from xml.etree import ElementTree
 
-from inspectortodo.main import print_xml
+from inspectortodo.main import print_xml, inspect
 from inspectortodo.todo import Todo
 
 XML_CONTENT = '<?xml version="1.0" encoding="UTF-8"?>\n' \
@@ -36,3 +37,9 @@ def test_print_xml():
 
     root = ElementTree.fromstring(xml_content)
     assert root is not None
+
+
+def test_inspect():
+    # This is an integration test, where we only care about the inspect()
+    # function not throwing.
+    inspect(os.path.dirname(__file__) + "/project_for_testing", r"IT-\d+")


### PR DESCRIPTION
A small change to make the inspect functionality available from within Python. :)

```
I hereby agree to the terms of the InspectorTodo Contributor License Agreement. codethief, git@codethief.eu
```
