### PR TITLE
Drop jira version restriction

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     click>=6.7
     click-log>=0.2.1
     GitPython>=2.1.9
-    jira>=1.0.15, <3.0.0
+    jira>=1.0.15
 [options.packages.find]
 where = src
 [options.entry_points]


### PR DESCRIPTION
* jira < 3.6 uses imghdr, which was deprecated in Python 3.11 and removed in Python 3.13.
* I couldn't find a problem with jira version above 3, so I think the restriction should be dropped.